### PR TITLE
Fix an issue with the build, missing operation in sequalize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ var searchIndex = sequelize.define(
   }
 );
 
-searchIndex.sync().success(function() {
+searchIndex.sync().then(function() {
   var data = getData();
   data.forEach(function(header) {
     var si = searchIndex.build({


### PR DESCRIPTION
The `.success()` operation is no longer there. This fixes it.